### PR TITLE
UE4 Build function fix

### DIFF
--- a/vars/ue4.groovy
+++ b/vars/ue4.groovy
@@ -41,7 +41,7 @@ def build(String projectDir, String projectName, String logFile = '', String pla
     bat label: 'Generate Project Files', script: "CALL \"${UnrealConfiguration.engineRootDirectory}/Engine/Binaries/DotNET/UnrealBuildTool.exe\" -projectfiles -project=\"${projectDir}/${projectName}.uproject\" -Game -Rocket -Progress -NoIntellisense -WaitMutex -Platforms=\"${platform}\" -Log=\"${logFile}\" PrecompileForTargets = PrecompileTargetsType.Any;"
     bat label: 'Build Editor Binaries', script: "CALL \"${UnrealConfiguration.engineRootDirectory}/Engine/Build/BatchFiles/Build.bat\" \"${projectName}Editor\" \"${projectDir}/${projectName}.uproject\" ${platform} Development -Log=\"${logFile}\""
 
-    if(configuration.toLowerCase() != 'development') {
+    if(configuration.toLowerCase() == 'development') {
         bat label: 'Build Project Binaries', script: "CALL \"${UnrealConfiguration.engineRootDirectory}/Engine/Build/BatchFiles/Build.bat\" \"${projectName}\" \"${projectDir}/${projectName}.uproject\" ${platform} ${configuration} -Log=\"${logFile}\""
     }
 }


### PR DESCRIPTION
Configuration should be equal to 'development', in other configurations we can't build modules.